### PR TITLE
Allow datapackage_checksums instead of datapackage_versions

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -195,7 +195,10 @@ pub struct RoomInfo {
     pub hint_cost: i32,
     pub location_check_points: i32,
     pub games: Vec<String>,
+    #[serde(default)]
     pub datapackage_versions: HashMap<String, i32>,
+    #[serde(default)]
+    pub datapackage_checksums: HashMap<String, String>,
     pub seed_name: String,
     pub time: f32,
 }
@@ -238,6 +241,7 @@ pub struct RoomUpdate {
     pub location_check_points: Option<i32>,
     pub games: Option<Vec<String>>,
     pub datapackage_versions: Option<HashMap<String, i32>>,
+    pub datapackage_checksums: Option<HashMap<String, String>>,
     pub seed_name: Option<String>,
     pub time: Option<f32>,
     // Exclusive to RoomUpdate


### PR DESCRIPTION
According to the [RoomInfo documentation](https://github.com/ArchipelagoMW/Archipelago/blob/main/docs/network%20protocol.md#RoomInfo), it now uses `datapackage_checksums` instead of the deprecrated `datapackage_versions`. This is also apparent when looking at the way the python client handles it ([first](https://github.com/ArchipelagoMW/Archipelago/blob/7621889b8b626e89947d6258ddd5ade65d434ddb/CommonClient.py#L832-L834), [second](https://github.com/ArchipelagoMW/Archipelago/blob/7621889b8b626e89947d6258ddd5ade65d434ddb/CommonClient.py#L535-L537)).